### PR TITLE
(feat) O3-3366: Add ability to filter lab order by `activatedOnOrAfterDate` params

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "@typescript-eslint/parser": "^5.59.9",
         "concurrently": "^7.6.0",
         "css-loader": "^6.8.1",
+        "dayjs": "^1.11.11",
         "eslint": "^8.42.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-config-ts-react-important-stuff": "^3.0.0",

--- a/src/components/orders-table/orders-data-table.scss
+++ b/src/components/orders-table/orders-data-table.scss
@@ -1,10 +1,9 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import "~@openmrs/esm-styleguide/src/vars";
-@import '../../root.scss';
+@use '@carbon/colors';
 
 .tableContainer {
-  background-color: $ui-01;
+  background-color: colors.$gray-10;
   margin: 0 spacing.$spacing-05;
   padding: 0;
 
@@ -17,11 +16,11 @@
   }
 
   th {
-    color: $text-02;
+    color: colors.$gray-70;
   }
 
   :global(.cds--data-table) {
-    background-color: $ui-03;
+    background-color: colors.$gray-20;
   }
 
   :global(.cds--table-toolbar) {
@@ -40,8 +39,18 @@
 }
 
 .toolbarItem {
+  display: flex;
   margin: 5px 10px;
+  align-items: center;
+
+  & p {
+    padding-right: 5px;
+    @include type.type-style('body-01');
+    color: colors.$gray-70;
+  }
 }
+
+
 
 .tableWrapper tr:last-of-type {
   td {
@@ -50,8 +59,8 @@
 }
 
 .tileContainer {
-  background-color: $ui-02;
-  border-top: 1px solid $ui-03;
+  background-color: colors.$white;
+  border-top: 1px solid colors.$gray-20;
   padding: 5rem 0;
 }
 
@@ -68,11 +77,10 @@
 
 .content {
   @include type.type-style('heading-compact-02');
-  color: $text-02;
+  color: colors.$gray-70;
   margin-bottom: 0.5rem;
 }
 
 .singleLineDisplay {
   white-space: nowrap;
 }
-

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,2 @@
 export const moduleName = "@openmrs/esm-laboratory-app";
+export const isoDateTimeString = "YYYY-MM-DDTHH:mm:ss.sss";

--- a/src/laboratory-resource.ts
+++ b/src/laboratory-resource.ts
@@ -12,7 +12,8 @@ import { useMemo } from "react";
  */
 export function useLabOrders(
   status: "NEW" | FulfillerStatus = null,
-  excludeCanceled = true
+  excludeCanceled = true,
+  activatedOnOrAfterDate?: string
 ) {
   const { laboratoryOrderTypeUuid } = useConfig();
   const fulfillerStatus = useMemo(
@@ -26,10 +27,13 @@ export function useLabOrders(
     ? `${url}&excludeCanceledAndExpired=true&excludeDiscontinueOrders=true`
     : url;
   // The usage of SWR's mutator seems to only suffice for cases where we don't apply a status filter
-  const refreshInterval = status ? 5000 : null;
-  const { data, error, mutate, isLoading } = useSWR<{
+  url = activatedOnOrAfterDate
+    ? `${url}&=&activatedOnOrAfterDate=${activatedOnOrAfterDate}`
+    : url;
+
+  const { data, error, mutate, isLoading, isValidating } = useSWR<{
     data: { results: Array<Order> };
-  }>(url, openmrsFetch, { refreshInterval });
+  }>(`${url}`, openmrsFetch);
 
   const filteredOrders =
     data?.data &&
@@ -42,6 +46,7 @@ export function useLabOrders(
     isLoading,
     isError: error,
     mutate,
+    isValidating,
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,6 +2732,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openmrs/esm-api@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-api@npm:5.6.1-pre.1820"
+  dependencies:
+    "@types/fhir": "npm:0.0.31"
+    lodash-es: "npm:^4.17.21"
+  peerDependencies:
+    "@openmrs/esm-config": 5.x
+    "@openmrs/esm-error-handling": 5.x
+    "@openmrs/esm-navigation": 5.x
+    "@openmrs/esm-offline": 5.x
+  checksum: 10/efd02dd083d217785675990ada0f3b10af7b0248bec19a7af20ed0665d1d26d415bc259e8569dfedb716498fcc717567877ea78a3846d73a1a27735308671685
+  languageName: node
+  linkType: hard
+
 "@openmrs/esm-app-shell@npm:5.5.1-pre.1771":
   version: 5.5.1-pre.1771
   resolution: "@openmrs/esm-app-shell@npm:5.5.1-pre.1771"
@@ -2780,6 +2795,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openmrs/esm-config@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-config@npm:5.6.1-pre.1820"
+  dependencies:
+    ramda: "npm:^0.26.1"
+  peerDependencies:
+    "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-state": 5.x
+    single-spa: 5.x
+  checksum: 10/5c2e7ef776eb5ce31ec992387ed141e199a125cbe40348b6ace61d4898cc010e626430573be8047ae2fb11e020b3b7cad873b83a7816ff61158a9a86b14b1afc
+  languageName: node
+  linkType: hard
+
 "@openmrs/esm-context@npm:5.5.1-pre.1771":
   version: 5.5.1-pre.1771
   resolution: "@openmrs/esm-context@npm:5.5.1-pre.1771"
@@ -2792,6 +2820,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openmrs/esm-context@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-context@npm:5.6.1-pre.1820"
+  dependencies:
+    immer: "npm:^10.0.4"
+  peerDependencies:
+    "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-state": 5.x
+  checksum: 10/770af13e795d302d8b4435d94ac09391154a52e430733be1144e145278c882a1e44e62a4b9d603890f77f79a0e3f290d5b47f9a2d037580343f0e4094891a72d
+  languageName: node
+  linkType: hard
+
 "@openmrs/esm-dynamic-loading@npm:5.5.1-pre.1771":
   version: 5.5.1-pre.1771
   resolution: "@openmrs/esm-dynamic-loading@npm:5.5.1-pre.1771"
@@ -2801,12 +2841,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openmrs/esm-dynamic-loading@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-dynamic-loading@npm:5.6.1-pre.1820"
+  peerDependencies:
+    "@openmrs/esm-globals": 5.x
+  checksum: 10/fe2fb58e768a3780219af08b417615281a31d10a900dc0d95c7aaf34633f0ef5fd1013f07bb2974254ac5f304f252780a3df3c8900f87112c3101ad32afbbab9
+  languageName: node
+  linkType: hard
+
 "@openmrs/esm-error-handling@npm:5.5.1-pre.1771":
   version: 5.5.1-pre.1771
   resolution: "@openmrs/esm-error-handling@npm:5.5.1-pre.1771"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
   checksum: 10/90037a11b1f943989483644c13f042ce41fba77c19a99f5f4428903747af7760fe32357e84b360d52764a0bae49605bfea0b580ac984fca947226f095caa0184
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-error-handling@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-error-handling@npm:5.6.1-pre.1820"
+  peerDependencies:
+    "@openmrs/esm-globals": 5.x
+  checksum: 10/8368060c8caf7d1b7cb4626c4d1faed1cb947bdfb816f3fe40d51c1781b76c376e24b90e065272c3596e760dc97b8c7827cf098e2e0566ab57dbf7f403beb782
   languageName: node
   linkType: hard
 
@@ -2826,6 +2884,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openmrs/esm-extensions@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-extensions@npm:5.6.1-pre.1820"
+  dependencies:
+    lodash-es: "npm:^4.17.21"
+  peerDependencies:
+    "@openmrs/esm-api": 5.x
+    "@openmrs/esm-config": 5.x
+    "@openmrs/esm-feature-flags": 5.x
+    "@openmrs/esm-state": 5.x
+    "@openmrs/esm-utils": 5.x
+    single-spa: 5.x
+  checksum: 10/d3abf4782c157e3df00959a7694eb8c7b104b9449f9870792983e38c2ec62e7e93ca74f8784785dfe96d7e29481c66277bb0b122ede1073f812d69d1ed03e07e
+  languageName: node
+  linkType: hard
+
 "@openmrs/esm-feature-flags@npm:5.5.1-pre.1771":
   version: 5.5.1-pre.1771
   resolution: "@openmrs/esm-feature-flags@npm:5.5.1-pre.1771"
@@ -2839,7 +2913,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-framework@npm:5.5.1-pre.1771, @openmrs/esm-framework@npm:next":
+"@openmrs/esm-feature-flags@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-feature-flags@npm:5.6.1-pre.1820"
+  dependencies:
+    ramda: "npm:^0.26.1"
+  peerDependencies:
+    "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-state": 5.x
+    single-spa: 5.x
+  checksum: 10/67587ca61dff90d6d3ec5b71148e0806d5de14a8044dda9efb803cc5934b5b519c4a4e8a58ed6db65e41cc49ba5609317d8a6406e4db0544bcdf1eaa6cd2172f
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-framework@npm:5.5.1-pre.1771":
   version: 5.5.1-pre.1771
   resolution: "@openmrs/esm-framework@npm:5.5.1-pre.1771"
   dependencies:
@@ -2873,12 +2960,57 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openmrs/esm-framework@npm:next":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-framework@npm:5.6.1-pre.1820"
+  dependencies:
+    "@openmrs/esm-api": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-config": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-context": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-dynamic-loading": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-error-handling": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-extensions": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-feature-flags": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-globals": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-navigation": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-offline": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-react-utils": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-routes": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-state": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-styleguide": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-translations": "npm:5.6.1-pre.1820"
+    "@openmrs/esm-utils": "npm:5.6.1-pre.1820"
+    dayjs: "npm:^1.10.7"
+  peerDependencies:
+    dayjs: 1.x
+    i18next: 21.x
+    react: 18.x
+    react-dom: 18.x
+    react-i18next: 11.x
+    rxjs: 6.x
+    single-spa: 5.x
+    swr: 2.x
+  checksum: 10/2d6a6cffce8c42bb3140eb731a5fdcd6e28ef2cf352feb9495f0c3682673b9cbd2bf67020d159dc269b67f3147d93eb3479788387b1d64c4985f495cbccfd78c
+  languageName: node
+  linkType: hard
+
 "@openmrs/esm-globals@npm:5.5.1-pre.1771":
   version: 5.5.1-pre.1771
   resolution: "@openmrs/esm-globals@npm:5.5.1-pre.1771"
   peerDependencies:
     single-spa: 5.x
   checksum: 10/7fa764687c5843a23b2c9501b9c72cda175e923570f6f5b42608ce894a14071ce8076654ee51e9991e6ff33fedfa1586ca0c9757f7d5447867beb6e9d225ff0a
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-globals@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-globals@npm:5.6.1-pre.1820"
+  dependencies:
+    "@types/fhir": "npm:0.0.31"
+  peerDependencies:
+    single-spa: 5.x
+  checksum: 10/36b15b95a266bd0f1ebe9e3f93e9fce2fdd294acbf088b9bec7903375faac50141d41f6b241584df66d046ae2fa3d785cb9b18f35c25d4b999ade5ca11805902
   languageName: node
   linkType: hard
 
@@ -2906,6 +3038,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^5.59.9"
     concurrently: "npm:^7.6.0"
     css-loader: "npm:^6.8.1"
+    dayjs: "npm:^1.11.11"
     eslint: "npm:^8.42.0"
     eslint-config-prettier: "npm:^8.8.0"
     eslint-config-ts-react-important-stuff: "npm:^3.0.0"
@@ -2953,6 +3086,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openmrs/esm-navigation@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-navigation@npm:5.6.1-pre.1820"
+  dependencies:
+    path-to-regexp: "npm:6.1.0"
+  peerDependencies:
+    "@openmrs/esm-state": 5.x
+  checksum: 10/3b270076b6b5ed6c85bd32d2d7c74f8072a764f6fa4b5cc3c287e85f828e5d02402f8dd3bd779b69d76e9865160cbbfb29659f3ae07662a2da6c5b4c27521e58
+  languageName: node
+  linkType: hard
+
 "@openmrs/esm-offline@npm:5.5.1-pre.1771":
   version: 5.5.1-pre.1771
   resolution: "@openmrs/esm-offline@npm:5.5.1-pre.1771"
@@ -2967,6 +3111,23 @@ __metadata:
     "@openmrs/esm-state": 5.x
     rxjs: 6.x
   checksum: 10/d1f3a953fa7486958316dd9dbdc8952f800724ebc91fc8768e60d8497ccd4a83aff409040456d8d950f3a601de28e463480f76ac88efcca9ff14685a79313ec9
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-offline@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-offline@npm:5.6.1-pre.1820"
+  dependencies:
+    dexie: "npm:^3.0.3"
+    lodash-es: "npm:^4.17.21"
+    uuid: "npm:^9.0.0"
+    workbox-window: "npm:^6.1.5"
+  peerDependencies:
+    "@openmrs/esm-api": 5.x
+    "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-state": 5.x
+    rxjs: 6.x
+  checksum: 10/2631e34fe10684d3dbf1de2ed5b2a73fb3c7a3adea0836ec8fa615423ce5f0d2a716e604343c30b764ed11b694db1a587dc99ce5e8f069d8f301b54d37a3c783
   languageName: node
   linkType: hard
 
@@ -3012,6 +3173,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openmrs/esm-react-utils@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-react-utils@npm:5.6.1-pre.1820"
+  dependencies:
+    lodash-es: "npm:^4.17.21"
+    single-spa-react: "npm:^6.0.0"
+  peerDependencies:
+    "@openmrs/esm-api": 5.x
+    "@openmrs/esm-config": 5.x
+    "@openmrs/esm-context": 5.x
+    "@openmrs/esm-error-handling": 5.x
+    "@openmrs/esm-extensions": 5.x
+    "@openmrs/esm-feature-flags": 5.x
+    "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-navigation": 5.x
+    "@openmrs/esm-utils": 5.x
+    dayjs: 1.x
+    i18next: 21.x
+    react: 18.x
+    react-dom: 18.x
+    react-i18next: 11.x
+    rxjs: 6.x
+    swr: 2.x
+  checksum: 10/706b35a0589fa99a8fd0bbc83e63988d032827fae08a71d494e7ee77c53b05487fa599b0029c98ea9607d9b4893420d27ec66dbdeb49601f9c405a30c761a6d9
+  languageName: node
+  linkType: hard
+
 "@openmrs/esm-routes@npm:5.5.1-pre.1771":
   version: 5.5.1-pre.1771
   resolution: "@openmrs/esm-routes@npm:5.5.1-pre.1771"
@@ -3019,6 +3207,16 @@ __metadata:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-utils": 5.x
   checksum: 10/fd5ffa78fa019c0553283450ffb9ada8b19a504e491379f30148b443068d6aa2cb6ec747ec91a18debf14b254d7c0ab8fb415270073d9f3bd763ddbb0a01cc86
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-routes@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-routes@npm:5.6.1-pre.1820"
+  peerDependencies:
+    "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-utils": 5.x
+  checksum: 10/0a89bee5bf6858d1ebb174efc0ca44b48ecb5674922154cf5139fd0983f4b3c69d90189c6354e8a7a6cde4b2fad821953fb2286df0af9ed299637de9e8415826
   languageName: node
   linkType: hard
 
@@ -3030,6 +3228,17 @@ __metadata:
   peerDependencies:
     "@openmrs/esm-globals": 5.x
   checksum: 10/b1ec5565d4d89bf582c60d3a881fa41e3cb71d022b77a9bcf103db2d7d17f8210eacdde6c18a3724cde43b47e4f88fd46cac3cd077215e29ff61db8ece9a4c9b
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-state@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-state@npm:5.6.1-pre.1820"
+  dependencies:
+    zustand: "npm:^4.3.6"
+  peerDependencies:
+    "@openmrs/esm-globals": 5.x
+  checksum: 10/e579f2d54441ad49789241b1a953195bced13b884f6f56d9e8d6baf5736413259dc7b3b9626cb3064315a3d5973f5fd3b725b38306c3b4a783558aa32a89fcdf
   languageName: node
   linkType: hard
 
@@ -3061,6 +3270,37 @@ __metadata:
     react-dom: 18.x
     rxjs: 6.x
   checksum: 10/4174887b196e4446f6b0cb98b8da58c70c43b2a32933020ddfc44d2ec76f19aad7a9f8b15c26c638351a53214bbf44eedfff63c58cba05e31929adfd40304615
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-styleguide@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-styleguide@npm:5.6.1-pre.1820"
+  dependencies:
+    "@carbon/charts": "npm:^1.12.0"
+    "@carbon/react": "npm:~1.37.0"
+    "@internationalized/date": "npm:^3.5.0"
+    "@react-spectrum/datepicker": "npm:^3.8.0"
+    "@react-spectrum/provider": "npm:^3.9.0"
+    "@react-spectrum/theme-default": "npm:^3.5.6"
+    core-js-pure: "npm:^3.36.0"
+    d3: "npm:^7.8.0"
+    geopattern: "npm:^1.2.3"
+    lodash-es: "npm:^4.17.21"
+    react-avatar: "npm:^5.0.3"
+  peerDependencies:
+    "@openmrs/esm-error-handling": 5.x
+    "@openmrs/esm-extensions": 5.x
+    "@openmrs/esm-navigation": 5.x
+    "@openmrs/esm-react-utils": 5.x
+    "@openmrs/esm-state": 5.x
+    "@openmrs/esm-translations": 5.x
+    dayjs: 1.x
+    i18next: 21.x
+    react: 18.x
+    react-dom: 18.x
+    rxjs: 6.x
+  checksum: 10/774e75fcd764d07f0ac7a8dd97138be7df03447c061e30ec41adbd2af9dcfba6d11a2eeddff0accf058b26dddf6aef61777957a367aa68ac78d9d109221e39d2
   languageName: node
   linkType: hard
 
@@ -3104,6 +3344,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openmrs/esm-translations@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-translations@npm:5.6.1-pre.1820"
+  dependencies:
+    i18next: "npm:21.10.0"
+  peerDependencies:
+    i18next: 21.x
+  checksum: 10/358d466d69776ced4ebc7b7da1bbbf898d5fa2e3e55b8495d6c66b32429e003c86a8e0fb2c4192d0791055095820a260358b57bd2284c84703fd4b4a1b3f9096
+  languageName: node
+  linkType: hard
+
 "@openmrs/esm-utils@npm:5.5.1-pre.1771":
   version: 5.5.1-pre.1771
   resolution: "@openmrs/esm-utils@npm:5.5.1-pre.1771"
@@ -3115,6 +3366,21 @@ __metadata:
     i18next: 21.x
     rxjs: 6.x
   checksum: 10/0df7eb8632c1546f9592908a12a0c45cfed20d1085c03a3154c8eb9919b1c82c7b46c4e223112ffb6f966494b797c7cb8af040bede1e6503a5087a94ba52690d
+  languageName: node
+  linkType: hard
+
+"@openmrs/esm-utils@npm:5.6.1-pre.1820":
+  version: 5.6.1-pre.1820
+  resolution: "@openmrs/esm-utils@npm:5.6.1-pre.1820"
+  dependencies:
+    "@internationalized/date": "npm:^3.5.0"
+    semver: "npm:7.3.2"
+  peerDependencies:
+    "@openmrs/esm-globals": 5.x
+    dayjs: 1.x
+    i18next: 21.x
+    rxjs: 6.x
+  checksum: 10/ce2cd5ebe8f6279c624f02194f935d8412284c62393192ab81ff0a7d3b9947450e2eeb172442c9042e46373fda2393d5e464c378b5087c3fd22f7b3ea40baafe
   languageName: node
   linkType: hard
 
@@ -7778,6 +8044,13 @@ __metadata:
   version: 1.11.10
   resolution: "dayjs@npm:1.11.10"
   checksum: 10/27e8f5bc01c0a76f36c656e62ab7f08c2e7b040b09e613cd4844abf03fb258e0350f0a83b02c887b84d771c1f11e092deda0beef8c6df2a1afbc3f6c1fade279
+  languageName: node
+  linkType: hard
+
+"dayjs@npm:^1.11.11":
+  version: 1.11.11
+  resolution: "dayjs@npm:1.11.11"
+  checksum: 10/f03948b172fbeed229837965988d1d5bac99c72a31c28731a457303259439f2f36289186489ae140adbeb10f591a926908c8de5d81eb449a2edbf5cbd6e9e30c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Update how we show default lab orders to default to current date orders. In addition include ability to filter by selected on or after date for the lab orders.

## Screenshots
![filterByDate](https://github.com/openmrs/openmrs-esm-laboratory-app/assets/28008754/b41531ed-6f01-4cde-93fa-94e13074be86)



## Related Issue
https://openmrs.atlassian.net/browse/O3-3366

## Other
