### PR TITLE
(feat) O3-3373: Add ability to mark fulfiller status as completed when saving test results

### DIFF
--- a/src/lab-tabs/data-table-extensions/completed-lab-requests-table.extension.tsx
+++ b/src/lab-tabs/data-table-extensions/completed-lab-requests-table.extension.tsx
@@ -5,7 +5,7 @@ const CompletedLabRequestsTable: React.FC = () => {
   return (
     <OrdersDataTable
       fulfillerStatus="COMPLETED"
-      excludeColumns={["actions"]}
+      excludeColumns={["actions", "action"]}
       excludeCanceledAndDiscontinuedOrders={false}
     />
   );


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR adds ability to transition order and mark it as completed once test result form has entered the results.
In addition i have also removed the `action` column on the completed lab tab
## Screenshot
https://github.com/openmrs/openmrs-esm-laboratory-app/assets/28008754/99c79421-9c02-4e84-a1dc-ec1a7fded5f6

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
