### PR TITLE
(fix) Update tsconfig to include "es2022"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
       "es2015.promise",
       "es2016.array.include",
       "es2018",
-      "es2020"
+      "es2020",
+      "es2022"
     ],
     "resolveJsonModule": true,
     "noEmit": true,


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Based on the comment on this PR https://github.com/openmrs/openmrs-esm-core/pull/1085. I updated the `tsconfig` to include "es2022" as a valid option to solve  Object.hasOwn() error.

## Screenshots
**Before upgrading the tsconfig file**

![Screenshot 2024-07-25 at 3 31 08 PM](https://github.com/user-attachments/assets/9de9f3cd-7c11-4683-aba1-67707543bbb4)


**After updating the tsconfig file**
![Screenshot 2024-07-25 at 3 35 46 PM](https://github.com/user-attachments/assets/32426f4e-26f8-4722-ba2e-c477eb10f1ff)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
