### PR TITLE
(fix) O3-3795: Adjust tile spacing in lab dashboard

### DIFF
--- a/src/lab-tiles/laboratory-summary-tiles.scss
+++ b/src/lab-tiles/laboratory-summary-tiles.scss
@@ -3,15 +3,14 @@
 @import "~@openmrs/esm-styleguide/src/vars";
 
 .cardContainer {
-  background-color: $ui-02 ;
+  background-color: $ui-02;
   display: flex;
+  flex-wrap: wrap;
   padding: 0 spacing.$spacing-05 spacing.$spacing-10 spacing.$spacing-03;
+  gap: spacing.$spacing-01;
 }
 
-.cardContainer > div:nth-child(1),
-.cardContainer > div:nth-child(2),
-.cardContainer > div:nth-child(3),
-.cardContainer > div:nth-child(4),
-.cardContainer > div:nth-child(5) {
-  width: 20%;
+.cardContainer > div {
+  flex: 1 1 300px;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The cardContainer on the Home page of the lab app has been updated to resolve the issue of excessive space on the right-hand side after verifying that the cardContainer was only rendering 3 cards instead of the anticipated 5, which caused the layout to have redundant space on the right.

## Screenshots
**Before fixing the changes** 

https://github.com/user-attachments/assets/f537ee00-d7f5-44d9-816b-ee61dab5c28e


**After fixing the proposed changes**


https://github.com/user-attachments/assets/940dc262-4e4a-4c23-b173-63c7379e7316


## Related Issue
https://openmrs.atlassian.net/browse/O3-3795

## Other
<!-- Anything not covered above -->
