### PR TITLE
tests ordered tabs and declined tests

### DIFF
--- a/src/components/orders-table/listOrderDetails.component.tsx
+++ b/src/components/orders-table/listOrderDetails.component.tsx
@@ -28,7 +28,10 @@ const ListOrderDetails: React.FC<ListOrdersDetailsProps> = (props) => {
                     return 0;
                   })
                   .map((action) => {
-                    if (action.actionName === "pickupLabRequest") {
+                    if (
+                      action.actionName === "pickupLabRequest" &&
+                      row.fulfillerStatus !== "DECLINED"
+                    ) {
                       return (
                         <Button
                           kind="primary"
@@ -61,7 +64,10 @@ const ListOrderDetails: React.FC<ListOrdersDetailsProps> = (props) => {
                         </Button>
                       );
                     }
-                    if (action.actionName === "rejectLabRequest") {
+                    if (
+                      action.actionName === "rejectLabRequest" &&
+                      row.fulfillerStatus !== "DECLINED"
+                    ) {
                       return (
                         <Button
                           kind="danger"

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,14 @@ export const completedLabRequestsTable = getAsyncLifecycle(
   options
 );
 
+export const declinedLabRequestsTable = getAsyncLifecycle(
+  () =>
+    import(
+      "./lab-tabs/data-table-extensions/declined-lab-requests-table.extension"
+    ),
+  options
+);
+
 export const worklistTile = getAsyncLifecycle(
   () => import("./lab-tiles/inprogress-lab-requests-tile.component"),
   options

--- a/src/lab-tabs/data-table-extensions/declined-lab-requests-table.extension.tsx
+++ b/src/lab-tabs/data-table-extensions/declined-lab-requests-table.extension.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import OrdersDataTable from "../../components/orders-table/orders-data-table.component";
+
+const DeclinedLabRequestsTable: React.FC = () => {
+  return (
+    <OrdersDataTable
+      fulfillerStatus="DECLINED"
+      excludeColumns={[]}
+      useActivatedOnOrAfterDateFilter={true}
+      excludeCanceledAndDiscontinuedOrders={false}
+      actions={[]}
+    />
+  );
+};
+
+export default DeclinedLabRequestsTable;

--- a/src/routes.json
+++ b/src/routes.json
@@ -51,6 +51,16 @@
                 "title": "In progress"
             }
         },
+
+        {
+            "name": "declined-lab-requests-table",
+            "slot": "lab-panels-slot",
+            "component": "declinedLabRequestsTable",
+            "meta": {
+                "name": "declinedPanel",
+                "title": "Declined"
+            }
+        },
         {
             "name": "completed-lab-requests-table",
             "slot": "lab-panels-slot",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Laboratory -> find a way like adding a tab to show rejected orders
                  -> currently if you reject a test you cant find it listed 
                  -> Declined tests should not allow further rejection or lab report submission

## Screenshots
![Screenshot from 2024-08-16 16-07-43](https://github.com/user-attachments/assets/a0d3074e-9563-4a97-9998-7d1c4f049045)
![Screenshot from 2024-08-16 16-07-58](https://github.com/user-attachments/assets/b71c2f50-9330-470c-bb7b-20929410dd5b)

## Related Issue

https://openmrs.atlassian.net/browse/O3-3816

## Other
<!-- Anything not covered above -->
