### PR TITLE
(refactor) O3-3813: Refactor input fields in ResultsFormField component

### DIFF
--- a/src/results/result-form-field.component.tsx
+++ b/src/results/result-form-field.component.tsx
@@ -21,9 +21,9 @@ const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control }) =
 
   const printValueRange = (concept: ConceptReference) => {
     if (concept?.datatype?.display === 'Numeric') {
-      const maxVal = Math.max(concept?.hiAbsolute ?? 0, concept?.hiCritical ?? 0, concept?.hiNormal ?? 0);
-      const minVal = Math.min(concept?.lowAbsolute ?? 0, concept?.lowCritical ?? 0, concept?.lowNormal ?? 0);
-      return `(${minVal} - ${maxVal > 0 ? maxVal : '--'} ${concept?.units ?? ''})`;
+      const maxVal = Math.max(concept?.hiAbsolute, concept?.hiCritical, concept?.hiNormal);
+      const minVal = Math.min(concept?.lowAbsolute, concept?.lowCritical, concept?.lowNormal);
+      return ` (${minVal ?? 0} - ${maxVal > 0 ? maxVal : '--'} ${concept?.units ?? ''})`;
     }
     return '';
   };
@@ -42,6 +42,28 @@ const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control }) =
               type="text"
               labelText={concept?.display ?? ''}
               autoFocus
+              allowEmpty
+            />
+          )}
+        />
+      )}
+
+      {isNumeric(concept) && (
+        <Controller
+          control={control}
+          name={concept.uuid}
+          render={({ field }) => (
+            <NumberInput
+              key={concept.uuid}
+              className={styles.numberInput}
+              value={field.value || ''}
+              onChange={(event) => field.onChange(event.target.value)}
+              label={concept?.display + printValueRange(concept)}
+              id={concept.uuid}
+              step={1}
+              autoFocus
+              hideSteppers
+              disableWheel
               allowEmpty
             />
           )}

--- a/src/results/result-form-field.component.tsx
+++ b/src/results/result-form-field.component.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import { Select, SelectItem, TextInput, NumberInput } from '@carbon/react';
-import { Controller } from 'react-hook-form';
+import { NumberInput, Select, SelectItem, TextInput } from '@carbon/react';
+import { Control, Controller, UseFormRegister } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { ConceptReference } from './result-form.resource';
 import styles from './result-form.scss';
 
 interface ResultFormFieldProps {
   concept: ConceptReference;
-  control: any;
-  register: any;
+  control: Control<any, any>;
+  register: UseFormRegister<{
+    testResult: string;
+  }>;
 }
 
 const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control }) => {
@@ -36,13 +38,12 @@ const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control }) =
           name={concept.uuid}
           render={({ field }) => (
             <TextInput
-              key={concept.uuid}
               className={styles.textInput}
-              {...field}
-              type="text"
+              id={concept.uuid}
+              key={concept.uuid}
               labelText={concept?.display ?? ''}
-              autoFocus
-              allowEmpty
+              type="text"
+              {...field}
             />
           )}
         />
@@ -54,17 +55,16 @@ const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control }) =
           name={concept.uuid}
           render={({ field }) => (
             <NumberInput
-              key={concept.uuid}
-              className={styles.numberInput}
-              value={field.value || ''}
-              onChange={(event) => field.onChange(event.target.value)}
-              label={concept?.display + printValueRange(concept)}
-              id={concept.uuid}
-              step={1}
-              autoFocus
-              hideSteppers
-              disableWheel
               allowEmpty
+              className={styles.numberInput}
+              disableWheel
+              hideSteppers
+              id={concept.uuid}
+              key={concept.uuid}
+              label={concept?.display + printValueRange(concept)}
+              onChange={(event) => field.onChange(event.target.value)}
+              step={0.01}
+              value={field.value || ''}
             />
           )}
         />
@@ -120,17 +120,16 @@ const ResultFormField: React.FC<ResultFormFieldProps> = ({ concept, control }) =
                 name={member.uuid}
                 render={({ field }) => (
                   <NumberInput
-                    key={member.uuid}
-                    className={styles.numberInput}
-                    value={field.value || ''}
-                    onChange={(event) => field.onChange(event.target.value)}
-                    label={member?.display + printValueRange(member)}
-                    id={member.uuid}
-                    step={1}
-                    autoFocus={index === 0}
-                    hideSteppers
-                    disableWheel
                     allowEmpty
+                    className={styles.numberInput}
+                    disableWheel
+                    hideSteppers
+                    id={member.uuid}
+                    key={member.uuid}
+                    label={member?.display + printValueRange(member)}
+                    onChange={(event) => field.onChange(event.target.value)}
+                    step={0.01}
+                    value={field.value || ''}
                   />
                 )}
               />

--- a/translations/en.json
+++ b/translations/en.json
@@ -29,7 +29,6 @@
   "noLabRequestsFoundC": "No lab requests found",
   "onHoldStatus": "ON_HOLD",
   "onOrAfterDateFilter": "Filter orders on or after",
-  "option": "Choose an option",
   "orderer": "orderer",
   "orderNumber": "Order number",
   "orderPickedSuccessfully": "You have successfully picked an order",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

I fixed the code to ensure TextInput component where concept.datatype.display is "Numeric" to use type="number"
and the TextInput component where concept.datatype.display is "Text" uses type="textInput"

## Screenshots



https://github.com/user-attachments/assets/636add88-bbcb-4236-a344-e27adb3f8d73




## Related Issue
https://openmrs.atlassian.net/browse/O3-3813

## Other
<!-- Anything not covered above -->
