### PR TITLE
(feat) O3-3846: Update Datepicker to use OpemrsDatePicker

### DIFF
--- a/src/components/orders-table/orders-date-range-picker.scss
+++ b/src/components/orders-table/orders-date-range-picker.scss
@@ -4,12 +4,23 @@
   display: flex;
   gap: layout.$spacing-03;
   align-items: center;
+  margin-bottom: 0;
+  padding-bottom: 0;
 }
 
 .dateRangePicker {
-  flex-grow: unset;
+  display: flex;
+  gap: layout.$spacing-02;
+  align-items: center;
+  margin-bottom: 0;
+}
 
-  input {
-    background-color: transparent;
-  }
+.datePickers {
+  display: flex;
+  gap: layout.$spacing-02;
+}
+
+.datePickers .bx--date-picker {
+  flex: 1;
+  min-width: 160px;
 }

--- a/src/components/orders-table/orders-date-range-picker.tsx
+++ b/src/components/orders-table/orders-date-range-picker.tsx
@@ -1,10 +1,36 @@
-import { DatePicker, DatePickerInput } from '@carbon/react';
-import { useAppContext } from '@openmrs/esm-framework';
-import dayjs from 'dayjs';
 import React from 'react';
+import { useAppContext, OpenmrsDatePicker } from '@openmrs/esm-framework';
+import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
 import { DateFilterContext } from '../../types';
 import styles from './orders-date-range-picker.scss';
+
+const OpenmrsDateRangePicker = ({ dateRange, onDateRangeChange, maxDate }) => {
+  const { t } = useTranslation();
+
+  const handleDateChange = (index, date) => {
+    const updatedDateRange = [...dateRange];
+    updatedDateRange[index] = date;
+    onDateRangeChange(updatedDateRange);
+  };
+
+  return (
+    <div className={styles.dateRangePicker}>
+      <p>{t('dateRange', 'Date range')}:</p>
+      <div className={styles.datePickers}>
+        {['start', 'finish'].map((type, index) => (
+          <OpenmrsDatePicker
+            key={type}
+            id={`date-picker-input-id-${type}`}
+            value={dateRange[index]}
+            onChange={(date) => handleDateChange(index, date)}
+            maxDate={maxDate}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
 
 export const OrdersDateRangePicker = () => {
   const currentDate = new Date();
@@ -13,25 +39,9 @@ export const OrdersDateRangePicker = () => {
     setDateRange: () => {},
   };
 
-  const { t } = useTranslation();
-
-  const handleOrdersDateRangeChange = (dates: Array<Date>) => {
-    setDateRange(dates);
-  };
-
   return (
     <div className={styles.datePickerWrapper}>
-      <p>{t('dateRange', 'Date range')}:</p>
-      <DatePicker
-        datePickerType="range"
-        className={styles.dateRangePicker}
-        onClose={handleOrdersDateRangeChange}
-        maxDate={currentDate.toISOString()}
-        value={dateRange}
-      >
-        <DatePickerInput id="date-picker-input-id-start" placeholder="dd/mm/yyyy" size="md" />
-        <DatePickerInput id="date-picker-input-id-finish" placeholder="dd/mm/yyyy" size="md" />
-      </DatePicker>
+      <OpenmrsDateRangePicker dateRange={dateRange} onDateRangeChange={setDateRange} maxDate={currentDate} />
     </div>
   );
 };


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
I fixed the `OrdersDateRangePicker` component to use the `OpenmrsDatePicker` component from the @openmrs/esm-framework allowing users to select start and finish dates within the current day while managing the state of the date range.

## Screenshots
<!-- Required if you are making UI changes. -->
https://github.com/user-attachments/assets/4b78af49-c80a-403e-9ac7-ca507ef15e69

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3846

## Other
<!-- Anything not covered above -->
