### PR TITLE
(fix) O3 4341: Fix modal close buttons placement in the lab app

### DIFF
--- a/src/lab-tabs/modals/pickup-lab-request-modal.component.tsx
+++ b/src/lab-tabs/modals/pickup-lab-request-modal.component.tsx
@@ -6,6 +6,7 @@ import { type Order } from '@openmrs/esm-patient-common-lib';
 import { restBaseUrl, showNotification, showSnackbar, useAbortController, useConfig } from '@openmrs/esm-framework';
 import { type Config } from '../../config-schema';
 import { setFulfillerStatus } from '../../laboratory-resource';
+import styles from './pickup-lab-request-modal.scss';
 
 interface PickupLabRequestModal {
   closeModal: () => void;
@@ -51,7 +52,11 @@ const PickupLabRequestModal: React.FC<PickupLabRequestModal> = ({ order, closeMo
 
   return (
     <div>
-      <ModalHeader closeModal={closeModal} title={t('pickRequest', 'Pick lab request')} />
+      <ModalHeader
+        closeModal={closeModal}
+        title={t('pickRequest', 'Pick lab request')}
+        className={styles.modalHeader}
+      />
       <ModalBody>
         <p>
           {t(

--- a/src/lab-tabs/modals/pickup-lab-request-modal.scss
+++ b/src/lab-tabs/modals/pickup-lab-request-modal.scss
@@ -1,0 +1,29 @@
+@use '@carbon/layout';
+
+.modalHeader {
+  :global {
+    .cds--modal-close-button {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      margin: 0;
+      margin-top: calc(-1 * #{layout.$spacing-05});
+    }
+
+    .cds--modal-close {
+      background-color: rgba(0, 0, 0, 0);
+
+      &:hover {
+        background-color: var(--cds-layer-hover);
+      }
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-content {
+      transform: translate(-4rem, 0.85rem);
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-caret {
+      transform: translate(-3.75rem, 1.25rem);
+    }
+  }
+}

--- a/src/lab-tabs/modals/reject-lab-request-modal.component.tsx
+++ b/src/lab-tabs/modals/reject-lab-request-modal.component.tsx
@@ -66,6 +66,7 @@ const RejectLabRequestModal: React.FC<RejectLabRequestModalProps> = ({ order, cl
       <ModalHeader
         closeModal={closeModal}
         title={`${t('rejectLabRequest', 'Reject lab request')} [${order.orderNumber}]`}
+        className={styles.modalHeader}
       />
       <ModalBody>
         <div className={styles.modalBody}>

--- a/src/lab-tabs/modals/reject-lab-request-modal.scss
+++ b/src/lab-tabs/modals/reject-lab-request-modal.scss
@@ -11,3 +11,31 @@ section {
 .modalBody {
   padding-bottom: layout.$spacing-05;
 }
+
+.modalHeader {
+  :global {
+    .cds--modal-close-button {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      margin: 0;
+      margin-top: calc(-1 * #{layout.$spacing-05});
+    }
+
+    .cds--modal-close {
+      background-color: rgba(0, 0, 0, 0);
+
+      &:hover {
+        background-color: var(--cds-layer-hover);
+      }
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-content {
+      transform: translate(-4rem, 0.85rem);
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-caret {
+      transform: translate(-3.75rem, 1.25rem);
+    }
+  }
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
while clicking the pick lab request in the laboratory  app and reject lab request 
modal pop for that close icon is not aligned correctly 
[close modal css is not aligned correctly ]
## Screenshots
<!-- Required if you are making
<img width="1470" alt="Screenshot 2025-01-14 at 8 36 06 AM" src="https://github.com/user-attachments/assets/96d987c4-ae3f-493b-9c73-557b099eddda" />

 UI changes. -->
# Before
<img width="1470" alt="Screenshot 2025-01-14 at 8 14 50 AM" src="https://github.com/user-attachments/assets/19d1777d-6b2e-4df8-a360-12daa9b2984b" />
<img width="1470" alt="Screenshot 2025-01-14 at 8 14 38 AM" src="https://github.com/user-attachments/assets/c02c47ea-177c-4186-9c5f-b304d4503ce3" />


# After
<img width="1470" alt="Screenshot 2025-01-14 at 8 35 57 AM" src="https://github.com/user-attachments/assets/0c99f353-196b-45ab-8e29-5eba5ee4ecff" />
<img width="1470" alt="Screenshot 2025-01-14 at 8 36 06 AM" src="https://github.com/user-attachments/assets/9b502b14-42b3-44e1-9c86-e1111c0b0f48" />

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
x
