### PR TITLE
(fix) O3-4398: Invalidate lab orders after submitting results form

### DIFF
--- a/src/lab-tabs/actions/add-lab-request-results-action.component.tsx
+++ b/src/lab-tabs/actions/add-lab-request-results-action.component.tsx
@@ -1,34 +1,35 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { Button } from '@carbon/react';
 import { mutate } from 'swr';
 import { useTranslation } from 'react-i18next';
-import { type Config } from '../../config-schema';
 import { launchWorkspace, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import { type Order } from '@openmrs/esm-patient-common-lib';
+import { type Config } from '../../config-schema';
 import styles from './actions.scss';
 
 interface AddLabRequestResultsActionProps {
   order: Order;
 }
+
 const AddLabRequestResultsAction: React.FC<AddLabRequestResultsActionProps> = ({ order }) => {
   const { t } = useTranslation();
   const { laboratoryOrderTypeUuid } = useConfig<Config>();
 
-  const mutateLabOrders = useCallback(() => {
+  const invalidateLabOrders = () => {
     mutate(
       (key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?orderTypes=${laboratoryOrderTypeUuid}`),
     );
-  }, [laboratoryOrderTypeUuid]);
+  };
 
-  const launchTestResultsWorkspace = useCallback(() => {
+  const launchTestResultsWorkspace = () => {
     launchWorkspace('test-results-form-workspace', {
       order,
-      mutateLabOrders,
+      invalidateLabOrders,
     });
-  }, [mutateLabOrders, order]);
+  };
 
   return (
-    <Button className={styles.actionButton} kind="primary" size="sm" onClick={launchTestResultsWorkspace}>
+    <Button className={styles.actionButton} kind="primary" onClick={launchTestResultsWorkspace} size="sm">
       {t('addLabResult', 'Add lab results')}
     </Button>
   );

--- a/src/lab-tabs/actions/add-lab-request-results-action.component.tsx
+++ b/src/lab-tabs/actions/add-lab-request-results-action.component.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button } from '@carbon/react';
+import { mutate } from 'swr';
 import { useTranslation } from 'react-i18next';
-import { type Config, launchWorkspace, restBaseUrl, useConfig } from '@openmrs/esm-framework';
+import { type Config } from '../../config-schema';
+import { launchWorkspace, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import { type Order } from '@openmrs/esm-patient-common-lib';
 import styles from './actions.scss';
-import { mutate } from 'swr';
 
 interface AddLabRequestResultsActionProps {
   order: Order;
@@ -13,24 +14,21 @@ const AddLabRequestResultsAction: React.FC<AddLabRequestResultsActionProps> = ({
   const { t } = useTranslation();
   const { laboratoryOrderTypeUuid } = useConfig<Config>();
 
+  const mutateLabOrders = useCallback(() => {
+    mutate(
+      (key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?orderTypes=${laboratoryOrderTypeUuid}`),
+    );
+  }, [laboratoryOrderTypeUuid]);
+
+  const launchTestResultsWorkspace = useCallback(() => {
+    launchWorkspace('test-results-form-workspace', {
+      order,
+      mutateLabOrders,
+    });
+  }, [mutateLabOrders, order]);
+
   return (
-    <Button
-      className={styles.actionButton}
-      kind="primary"
-      size="sm"
-      key={`${order.uuid}`}
-      onClick={() => {
-        launchWorkspace('test-results-form-workspace', {
-          order,
-          mutateLabOrders: () => {
-            mutate(
-              (key) =>
-                typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?orderTypes=${laboratoryOrderTypeUuid}`),
-            );
-          },
-        });
-      }}
-    >
+    <Button className={styles.actionButton} kind="primary" size="sm" onClick={launchTestResultsWorkspace}>
       {t('addLabResult', 'Add lab results')}
     </Button>
   );

--- a/src/lab-tabs/actions/add-lab-request-results-action.component.tsx
+++ b/src/lab-tabs/actions/add-lab-request-results-action.component.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { Button } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { launchWorkspace } from '@openmrs/esm-framework';
+import { type Config, launchWorkspace, restBaseUrl, useConfig } from '@openmrs/esm-framework';
 import { type Order } from '@openmrs/esm-patient-common-lib';
 import styles from './actions.scss';
+import { mutate } from 'swr';
 
 interface AddLabRequestResultsActionProps {
   order: Order;
 }
 const AddLabRequestResultsAction: React.FC<AddLabRequestResultsActionProps> = ({ order }) => {
   const { t } = useTranslation();
+  const { laboratoryOrderTypeUuid } = useConfig<Config>();
 
   return (
     <Button
@@ -17,7 +19,17 @@ const AddLabRequestResultsAction: React.FC<AddLabRequestResultsActionProps> = ({
       kind="primary"
       size="sm"
       key={`${order.uuid}`}
-      onClick={() => launchWorkspace('test-results-form-workspace', { order })}
+      onClick={() => {
+        launchWorkspace('test-results-form-workspace', {
+          order,
+          mutateLabOrders: () => {
+            mutate(
+              (key) =>
+                typeof key === 'string' && key.startsWith(`${restBaseUrl}/order?orderTypes=${laboratoryOrderTypeUuid}`),
+            );
+          },
+        });
+      }}
     >
       {t('addLabResult', 'Add lab results')}
     </Button>

--- a/src/laboratory-resource.ts
+++ b/src/laboratory-resource.ts
@@ -26,7 +26,7 @@ export function useLabOrders(status: 'NEW' | FulfillerStatus = null, excludeCanc
   url = excludeCanceled ? `${url}&excludeCanceledAndExpired=true&excludeDiscontinueOrders=true` : url;
   // The usage of SWR's mutator seems to only suffice for cases where we don't apply a status filter
   url = dateRange
-    ? `${url}&=&activatedOnOrAfterDate=${dateRange.at(0).toISOString()}&activatedOnOrBeforeDate=${dateRange
+    ? `${url}&activatedOnOrAfterDate=${dateRange.at(0).toISOString()}&activatedOnOrBeforeDate=${dateRange
         .at(1)
         .toISOString()}`
     : url;
@@ -47,6 +47,7 @@ export function useLabOrders(status: 'NEW' | FulfillerStatus = null, excludeCanc
     isValidating,
   };
 }
+
 export function useSearchGroupedResults(data: Array<GroupedOrders>, searchString: string) {
   const searchResults = useMemo(() => {
     if (searchString && searchString.trim() !== '') {
@@ -66,6 +67,7 @@ export function useSearchGroupedResults(data: Array<GroupedOrders>, searchString
 
   return searchResults;
 }
+
 export function setFulfillerStatus(orderId: string, status: FulfillerStatus, abortController: AbortController) {
   return openmrsFetch(`${restBaseUrl}/order/${orderId}/fulfillerdetails/`, {
     method: 'POST',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR fixes an issue whereby the lab order would not automatically be transitioned to the complete status whenever a user finishes adding lab results.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/883336ff-0c23-4d3b-b194-74098a18312e


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4398
## Other
<!-- Anything not covered above -->
This work is dependent on the work on the patient chart app that makes the workspace accept the `mutateLabOrders` prop that I pass on this PR. So ideally both of these PRs should be merged at the same time.

The PR on the patient chart orders app can be found [here.](https://github.com/openmrs/openmrs-esm-patient-chart/pull/2225)