### PR TITLE
(fix) Orders data table UI fixes

### DIFF
--- a/src/components/orders-table/list-order-details.component.tsx
+++ b/src/components/orders-table/list-order-details.component.tsx
@@ -9,7 +9,7 @@ import {
   StructuredListWrapper,
   Tag,
 } from '@carbon/react';
-import capitalize from 'lodash-es/capitalize';
+import { capitalize } from 'lodash-es';
 import { ExtensionSlot } from '@openmrs/esm-framework';
 import { type ListOrdersDetailsProps } from '../../types';
 import styles from './list-order-details.scss';
@@ -50,7 +50,7 @@ const ListOrderDetails: React.FC<ListOrdersDetailsProps> = (props) => {
                     <StructuredListCell>{t('testOrdered', 'Test ordered: ')}</StructuredListCell>
                     <StructuredListCell>{capitalize(row?.display)}</StructuredListCell>
                     <br />
-                    <StructuredListCell>
+                    <StructuredListCell className={styles.instructionLabel}>
                       <span className={styles.instructionLabel}>{t('orderInStruction', 'Instructions: ')}</span>
                       <span className={styles.instructions}>
                         {row.instructions ?? (
@@ -92,7 +92,7 @@ const ListOrderDetails: React.FC<ListOrdersDetailsProps> = (props) => {
                   <StructuredListCell>{row.fulfillerComment}</StructuredListCell>
                 </StructuredListRow>
               )}
-              <StructuredListRow>
+              <StructuredListRow className={styles.nameOrderRow}>
                 <StructuredListCell>
                   <span className={styles.nameOrder}>
                     {t('ordererName', 'Orderer Name: ')} {capitalize(row.orderer?.display)}

--- a/src/components/orders-table/list-order-details.component.tsx
+++ b/src/components/orders-table/list-order-details.component.tsx
@@ -50,15 +50,17 @@ const ListOrderDetails: React.FC<ListOrdersDetailsProps> = (props) => {
                     <StructuredListCell>{t('testOrdered', 'Test ordered: ')}</StructuredListCell>
                     <StructuredListCell>{capitalize(row?.display)}</StructuredListCell>
                     <br />
-                    <StructuredListCell className={styles.instructionLabel}>
-                      <span className={styles.instructionLabel}>{t('orderInStruction', 'Instructions: ')}</span>
-                      <span className={styles.instructions}>
-                        {row.instructions ?? (
-                          <Tag size="lg" type="red">
-                            {t('NoInstructionLeft', 'No instructions are provided.')}
-                          </Tag>
-                        )}
-                      </span>
+                    <StructuredListCell>
+                      <div className={styles.instructionLabelContainer}>
+                        <span className={styles.instructionLabel}>{t('orderInStruction', 'Instructions: ')}</span>
+                        <span className={styles.instructions}>
+                          {row.instructions ?? (
+                            <Tag size="lg" type="red">
+                              {t('NoInstructionLeft', 'No instructions are provided.')}
+                            </Tag>
+                          )}
+                        </span>
+                      </div>
                     </StructuredListCell>
                   </StructuredListRow>
                 </StructuredListBody>

--- a/src/components/orders-table/list-order-details.scss
+++ b/src/components/orders-table/list-order-details.scss
@@ -12,6 +12,10 @@
   gap: 10rem;
 }
 
+.nameOrderRow {
+  border-top: none;
+}
+
 .nameOrder {
   // TODO: Prefer type styles over scales as mentioned here: https://carbondesignsystem.com/elements/typography/code/#type-scale
   font-size: type.type-scale(2);
@@ -103,4 +107,10 @@
 
 .accordionTitle {
   font-weight: bold;
+}
+
+.instructionLabel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/src/components/orders-table/list-order-details.scss
+++ b/src/components/orders-table/list-order-details.scss
@@ -109,7 +109,7 @@
   font-weight: bold;
 }
 
-.instructionLabel {
+.instructionLabelContainer {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/orders-table/orders-data-table.component.tsx
+++ b/src/components/orders-table/orders-data-table.component.tsx
@@ -27,13 +27,13 @@ import { useLabOrders, useSearchGroupedResults } from '../../laboratory-resource
 import type { FulfillerStatus, OrdersDataTableProps } from '../../types';
 import { OrdersDateRangePicker } from './orders-date-range-picker.component';
 import ListOrderDetails from './list-order-details.component';
-import styles from './orders-data-table.scss';
 import TransitionLatestQueueEntryButton from '../../lab-tabs/actions/transition-patient-to-new-queue/transition-patient-to-new-queue.component';
+import styles from './orders-data-table.scss';
 
 const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
   const { t } = useTranslation();
   const [filter, setFilter] = useState<FulfillerStatus>(null);
-  const [searchString, setSearchString] = useState<string>('');
+  const [searchString, setSearchString] = useState('');
 
   const { labOrders, isLoading } = useLabOrders(
     props.useFilter ? filter : props.fulfillerStatus,
@@ -126,7 +126,7 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
   }
 
   return (
-    <DataTable rows={tableRows} headers={columns} useZebraStyles>
+    <DataTable rows={tableRows} headers={columns} useZebraStyles={labOrders?.length > 1}>
       {({ getExpandHeaderProps, getHeaderProps, getRowProps, getTableProps, headers, rows }) => (
         <TableContainer className={styles.tableContainer}>
           <TableToolbar>
@@ -157,7 +157,7 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
               </Layer>
             </TableToolbarContent>
           </TableToolbar>
-          <Table {...getTableProps()} className={styles.tableWrapper}>
+          <Table className={styles.tableWrapper} {...getTableProps()}>
             <TableHead>
               <TableRow>
                 <TableExpandHeader enableToggle={rows.length > 0} {...getExpandHeaderProps()} />
@@ -175,13 +175,15 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
                     ))}
                   </TableExpandRow>
                   {row.isExpanded ? (
-                    <TableExpandedRow colSpan={headers.length + 1}>
+                    <TableExpandedRow colSpan={headers.length + 2}>
                       <ListOrderDetails
                         actions={props.actions}
                         groupedOrders={groupedOrdersByPatient.find((item) => item.patientId === row.id)}
                       />
                     </TableExpandedRow>
-                  ) : null}
+                  ) : (
+                    <TableExpandedRow className={styles.hiddenRow} colSpan={headers.length + 2} />
+                  )}
                 </React.Fragment>
               ))}
             </TableBody>


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR makes the following changes to the Orders data table:

- Conditionally applying the zebra striping to the table rows based on the number of orders.
- Removing an unnecessary top border from the name order row.

## Screenshots

### Before

![CleanShot 2025-02-04 at 12  54 11@2x](https://github.com/user-attachments/assets/5a77b5c1-24f3-4b1f-908b-d7f47e979121)

### After

![CleanShot 2025-02-04 at 12  45 28@2x](https://github.com/user-attachments/assets/0e375e7b-a7ed-4ee7-81d8-e1fec7221274)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
