### PR TITLE
(fix) Fix invalid date error in laboratory dashboard

### DIFF
--- a/src/components/orders-table/orders-date-range-picker.component.tsx
+++ b/src/components/orders-table/orders-date-range-picker.component.tsx
@@ -7,13 +7,13 @@ import { type DateFilterContext } from '../../types';
 import styles from './orders-date-range-picker.scss';
 
 export const OrdersDateRangePicker = () => {
+  const { t } = useTranslation();
   const currentDate = new Date();
+
   const { dateRange, setDateRange } = useAppContext<DateFilterContext>('laboratory-date-filter') ?? {
     dateRange: [dayjs().startOf('day').toDate(), new Date()],
     setDateRange: () => {},
   };
-
-  const { t } = useTranslation();
 
   const handleOrdersDateRangeChange = (dates: Array<Date>) => {
     setDateRange(dates);
@@ -23,9 +23,10 @@ export const OrdersDateRangePicker = () => {
     <div className={styles.datePickerWrapper}>
       <p>{t('dateRange', 'Date range')}:</p>
       <DatePicker
-        datePickerType="range"
         className={styles.dateRangePicker}
-        onClose={handleOrdersDateRangeChange}
+        dateFormat="d/m/Y"
+        datePickerType="range"
+        onChange={handleOrdersDateRangeChange}
         maxDate={currentDate.toISOString()}
         value={dateRange}
       >

--- a/src/laboratory-dashboard.component.tsx
+++ b/src/laboratory-dashboard.component.tsx
@@ -1,12 +1,12 @@
-import { LaboratoryPictogram, PageHeader, useDefineAppContext } from '@openmrs/esm-framework';
-import dayjs from 'dayjs';
 import React, { useState } from 'react';
+import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';
-import Overlay from './components/overlay/overlay.component';
+import { LaboratoryPictogram, PageHeader, useDefineAppContext } from '@openmrs/esm-framework';
+import { type DateFilterContext } from './types';
 import LaboratoryOrdersTabs from './lab-tabs/laboratory-tabs.component';
 import LaboratorySummaryTiles from './lab-tiles/laboratory-summary-tiles.component';
+import Overlay from './components/overlay/overlay.component';
 import styles from './laboratory-dashboard.scss';
-import { type DateFilterContext } from './types';
 
 const LaboratoryDashboard: React.FC = () => {
   const { t } = useTranslation();
@@ -14,7 +14,7 @@ const LaboratoryDashboard: React.FC = () => {
   useDefineAppContext<DateFilterContext>('laboratory-date-filter', { dateRange, setDateRange });
 
   return (
-    <div className={`omrs-main-content`}>
+    <div>
       <PageHeader
         illustration={<LaboratoryPictogram />}
         title={t('laboratory', 'Laboratory')}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes an issue where the date range picker in the laboratory dashboard was throwing an error because the default date format for the Carbon date picker is `m/d/Y` while the date range picker was providing dates in the format `d/m/Y`. Explicitly setting the date format to `d/m/Y` fixes the issue.

Other unrelated changes in the diff include:

- Removing the `omrs-main-content` class from the laboratory dashboard, as it doesn't do anything useful
- Reordering imports for easier reading
- Replacing the date range picker's `onClose` prop with an `onChange` prop, allowing date range changes to be reflected in the UI immediately


## Screenshots

## Errors in the devtools console

![CleanShot 2025-02-25 at 11  46 44@2x](https://github.com/user-attachments/assets/fcc9e153-d97b-45e9-8eae-fae74399fde7)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
