### PR TITLE
(feat) O3-4545: Hide transition button on the laboratory esm for patients doesn't have an active visit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ dist/
 !.yarn/versions
 
 .turbo
+.qodo

--- a/src/lab-tabs/actions/transition-patient-to-new-queue/transition-patient-to-new-queue.component.tsx
+++ b/src/lab-tabs/actions/transition-patient-to-new-queue/transition-patient-to-new-queue.component.tsx
@@ -10,7 +10,11 @@ interface TransitionLatestQueueEntryButtonProps {
 
 const TransitionLatestQueueEntryButton: React.FC<TransitionLatestQueueEntryButtonProps> = ({ patientUuid }) => {
   const { activeVisit, isLoading } = useVisit(patientUuid);
+  const shouldHideButton = !activeVisit;
   const { t } = useTranslation();
+  if (shouldHideButton) {
+    return null;
+  }
 
   const handleLaunchModal = () => {
     const dispose = showModal('transition-patient-to-latest-queue-modal', {
@@ -30,7 +34,6 @@ const TransitionLatestQueueEntryButton: React.FC<TransitionLatestQueueEntryButto
       onClick={handleLaunchModal}
       renderIcon={AirlineManageGates}
       size="sm"
-      disabled={!activeVisit}
     >
       {t('transition', 'Transition')}
     </Button>

--- a/src/lab-tabs/actions/transition-patient-to-new-queue/transition-patient-to-new-queue.component.tsx
+++ b/src/lab-tabs/actions/transition-patient-to-new-queue/transition-patient-to-new-queue.component.tsx
@@ -1,22 +1,27 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@carbon/react';
+import { Button, InlineLoading } from '@carbon/react';
 import { AirlineManageGates } from '@carbon/react/icons';
-import { showModal } from '@openmrs/esm-framework';
+import { showModal, useVisit } from '@openmrs/esm-framework';
 
 interface TransitionLatestQueueEntryButtonProps {
   patientUuid: string;
 }
 
 const TransitionLatestQueueEntryButton: React.FC<TransitionLatestQueueEntryButtonProps> = ({ patientUuid }) => {
+  const { activeVisit, isLoading } = useVisit(patientUuid);
   const { t } = useTranslation();
 
   const handleLaunchModal = () => {
     const dispose = showModal('transition-patient-to-latest-queue-modal', {
       closeModal: () => dispose(),
-      patientUuid,
+      activeVisit,
     });
   };
+
+  if (isLoading) {
+    return <InlineLoading description={t('loading', 'Loading...')} />;
+  }
 
   return (
     <Button
@@ -25,6 +30,7 @@ const TransitionLatestQueueEntryButton: React.FC<TransitionLatestQueueEntryButto
       onClick={handleLaunchModal}
       renderIcon={AirlineManageGates}
       size="sm"
+      disabled={!activeVisit}
     >
       {t('transition', 'Transition')}
     </Button>

--- a/src/lab-tabs/actions/transition-patient-to-new-queue/transition-patient-to-new-queue.test.tsx
+++ b/src/lab-tabs/actions/transition-patient-to-new-queue/transition-patient-to-new-queue.test.tsx
@@ -1,12 +1,26 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { showModal } from '@openmrs/esm-framework';
+import { showModal, useVisit } from '@openmrs/esm-framework';
 import { mockPatient } from '@tools';
 import TransitionLatestQueueEntryButton from './transition-patient-to-new-queue.component';
 
+jest.mock('@openmrs/esm-framework', () => ({
+  showModal: jest.fn(),
+  useVisit: jest.fn(),
+}));
+
 describe('TransitionLatestQueueEntryButton', () => {
   const patientUuid = mockPatient.id;
+  const mockActiveVisit = { uuid: 'visit-uuid', display: 'Test Visit' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useVisit as jest.Mock).mockReturnValue({
+      activeVisit: mockActiveVisit,
+      isLoading: false,
+    });
+  });
 
   it('should render a button', () => {
     render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
@@ -25,8 +39,31 @@ describe('TransitionLatestQueueEntryButton', () => {
       'transition-patient-to-latest-queue-modal',
       expect.objectContaining({
         closeModal: expect.any(Function),
-        patientUuid,
+        activeVisit: mockActiveVisit,
       }),
     );
+  });
+
+  it('should show loading state when visit data is loading', () => {
+    (useVisit as jest.Mock).mockReturnValue({
+      activeVisit: null,
+      isLoading: true,
+    });
+
+    render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should disable the button when no active visit exists', () => {
+    (useVisit as jest.Mock).mockReturnValue({
+      activeVisit: null,
+      isLoading: false,
+    });
+
+    render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
+
+    expect(screen.getByRole('button', { name: /transition/i })).toBeDisabled();
   });
 });

--- a/src/lab-tabs/actions/transition-patient-to-new-queue/transition-patient-to-new-queue.test.tsx
+++ b/src/lab-tabs/actions/transition-patient-to-new-queue/transition-patient-to-new-queue.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { showModal, useVisit } from '@openmrs/esm-framework';
-import { mockPatient } from '@tools';
 import TransitionLatestQueueEntryButton from './transition-patient-to-new-queue.component';
 
 jest.mock('@openmrs/esm-framework', () => ({
@@ -11,7 +10,7 @@ jest.mock('@openmrs/esm-framework', () => ({
 }));
 
 describe('TransitionLatestQueueEntryButton', () => {
-  const patientUuid = mockPatient.id;
+  const patientUuid = 'patient-uuid';
   const mockActiveVisit = { uuid: 'visit-uuid', display: 'Test Visit' };
 
   beforeEach(() => {
@@ -22,7 +21,7 @@ describe('TransitionLatestQueueEntryButton', () => {
     });
   });
 
-  it('should render a button', () => {
+  it('should render a button when an active visit exists', () => {
     render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
 
     expect(screen.getByRole('button', { name: /transition/i })).toBeInTheDocument();
@@ -52,11 +51,10 @@ describe('TransitionLatestQueueEntryButton', () => {
 
     render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
 
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
-  it('should disable the button when no active visit exists', () => {
+  it('should not render the button when no active visit exists', () => {
     (useVisit as jest.Mock).mockReturnValue({
       activeVisit: null,
       isLoading: false,
@@ -64,6 +62,6 @@ describe('TransitionLatestQueueEntryButton', () => {
 
     render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
 
-    expect(screen.getByRole('button', { name: /transition/i })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /transition/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Previously, the "Transition" button was available even when a patient did not have an active visit, leading to unintended actions. This update ensures that the button is disabled for patients without an active visit, preventing errors in patient transitions.

Additionally, a modal has been added to allow adding the patient to the queue before transitioning, ensuring a smooth and structured workflow.

## Screenshots
<!-- Required if you are making UI changes. -->
Bug video
![fixbug-queue](https://github.com/user-attachments/assets/2c11d30f-69da-4587-86bb-d08a5a120174)

Fixes Video
![fix-fixes](https://github.com/user-attachments/assets/b3216daa-e1de-43e8-a732-bd7a2a0c02bf)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4545
https://thepalladiumgroup.atlassian.net/browse/KHP3-7467


## Other
<!-- Anything not covered above -->
