### PR TITLE
(fix) Use patient person display for patient name

### DIFF
--- a/src/components/orders-table/orders-data-table.component.tsx
+++ b/src/components/orders-table/orders-data-table.component.tsx
@@ -48,7 +48,7 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
         return {
           ...order,
           dateActivated: formatDate(parseDate(order.dateActivated)),
-          patientName: order.patient?.person?.display,
+          patientName: order.patient?.person.display,
           patientUuid: order.patient?.uuid,
           patientAge: order.patient?.person?.age,
           status: order.fulfillerStatus ?? '--',
@@ -122,7 +122,7 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
   const tableRows = useMemo(() => {
     return paginatedLabOrders.map((order) => ({
       id: order.patientId,
-      patientName: order.orders[0]?.patient?.person?.display || '',
+      patientName: order.orders[0]?.patient.person.display,
       orders: order.orders,
       totalOrders: order.orders?.length,
       patientAge: order.orders[0]?.patient?.person?.age,

--- a/src/components/orders-table/orders-data-table.component.tsx
+++ b/src/components/orders-table/orders-data-table.component.tsx
@@ -48,7 +48,7 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
         return {
           ...order,
           dateActivated: formatDate(parseDate(order.dateActivated)),
-          patientName: order.patient?.display.split('-')[1],
+          patientName: order.patient?.person?.display,
           patientUuid: order.patient?.uuid,
           patientAge: order.patient?.person?.age,
           status: order.fulfillerStatus ?? '--',
@@ -122,7 +122,7 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
   const tableRows = useMemo(() => {
     return paginatedLabOrders.map((order) => ({
       id: order.patientId,
-      patientName: order.orders[0]?.patient?.display?.split('-')[1]?.trim() || '',
+      patientName: order.orders[0]?.patient?.person?.display || '',
       orders: order.orders,
       totalOrders: order.orders?.length,
       patientAge: order.orders[0]?.patient?.person?.age,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Uses patient person display instead of the generated patient display. The latter is a combination of the unique identifier and patient name with the identifier varying for different organizations. 

Using the `split('-')` when the identifier has a hyphen (-) breaks the logic 

<img width="454" alt="Screenshot 2025-04-29 at 12 35 08" src="https://github.com/user-attachments/assets/1d99f0f0-08ed-461f-8192-706a444c6f96" />

For the example above, we end up with `25` which is part of the identifier instead of the patient name

<img width="921" alt="Screenshot 2025-04-29 at 12 37 35" src="https://github.com/user-attachments/assets/09ee946c-3fa2-45da-9a15-3cd79bd3deb5" />

## Screenshots

After switching to person display

<img width="922" alt="Screenshot 2025-04-29 at 12 40 10" src="https://github.com/user-attachments/assets/1400277b-8e67-42ad-86d7-700c5ca9ac4d" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
