### PR TITLE
(chore) Fix i18next translation extraction to cover all TypeScript source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typescript": "tsc",
     "test": "jest --config jest.config.js --passWithNoTests --color",
     "verify": "turbo lint typescript test --color",
-    "extract-translations": "i18next 'src/**/*.component.tsx' 'src/index.ts' --config ./tools/i18next-parser.config.js",
+    "extract-translations": "i18next 'src/**/*.{ts,tsx}' --config ./tools/i18next-parser.config.js",
     "coverage": "yarn test -- --coverage",
     "postinstall": "husky install",
     "test-e2e": "playwright test"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { capitalize } from 'lodash-es';
+import { type TFunction } from 'i18next';
 import { type OrderUrgency } from '@openmrs/esm-framework';
 
 export const urgencyTagType: Record<OrderUrgency, 'red' | 'green' | 'gray'> = {
@@ -11,7 +12,7 @@ export const urgencyPriority: Record<string, number> = { STAT: 0, ROUTINE: 1, ON
 
 export function formatUrgencyLabel(
   urgency: (OrderUrgency & {}) | (string & {}) | null | undefined,
-  t: (key: string, fallback: string) => string,
+  t: TFunction,
 ): string {
   if (!urgency) return '';
   switch (urgency) {

--- a/tools/i18next-parser.config.js
+++ b/tools/i18next-parser.config.js
@@ -8,7 +8,7 @@ module.exports = {
   defaultNamespace: "translations",
   // Default namespace used in your i18next config
 
-  defaultValue: (_, __, key) => key,
+  defaultValue: (_, __, key, value) => value || key,
   // Default value to give to empty keys
   // You may also specify a function accepting the locale, namespace, and key as arguments
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary

- Fixes `extract-translations` script to scan `src/**/*.{ts,tsx}` instead of only `*.component.tsx` and `src/index.ts`, so translation keys in utility files (e.g. `src/utils.ts`) are no longer silently missed
- Switches `formatUrgencyLabel`'s `t` parameter type from a hand-rolled function signature to the standard `TFunction` from i18next, which is what the parser expects
- Fixes `defaultValue` in `tools/i18next-parser.config.js` to use the value extracted from source (e.g. `'Stat'` from `t('stat', 'Stat')`) rather than always falling back to the lowercase key name

## Screenshots

<!-- Required if you are making UI changes. -->

## Related Issue

<!-- https://issues.openmrs.org/browse/O3- -->

## Other

<!-- Anything not covered above -->