### PR TITLE
(fix) Make search toolbar responsive based on layout type

### DIFF
--- a/src/components/orders-table/orders-data-table.component.tsx
+++ b/src/components/orders-table/orders-data-table.component.tsx
@@ -24,7 +24,15 @@ import {
   Tile,
 } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { ExtensionSlot, formatDate, parseDate, showModal, useConfig, usePagination } from '@openmrs/esm-framework';
+import {
+  ExtensionSlot,
+  formatDate,
+  parseDate,
+  showModal,
+  useConfig,
+  useLayoutType,
+  usePagination,
+} from '@openmrs/esm-framework';
 import { OrdersDateRangePicker } from './orders-date-range-picker.component';
 import ListOrderDetails from './list-order-details.component';
 import { useLabOrders } from '../../laboratory.resource';
@@ -98,6 +106,8 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
   const [filter, setFilter] = useState<FulfillerStatus>(null);
   const [searchString, setSearchString] = useState('');
   const { labTableColumns, patientIdIdentifierTypeUuid } = useConfig<Config>();
+  const isTablet = useLayoutType() === 'tablet';
+  const responsiveSize: 'sm' | 'lg' = isTablet ? 'lg' : 'sm';
 
   const { labOrders, isLoading } = useLabOrders({
     status: props.useFilter ? filter : props.fulfillerStatus,
@@ -306,7 +316,7 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
                   expanded
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchString(e.target.value)}
                   placeholder={t('searchThisList', 'Search this list')}
-                  size="sm"
+                  size={responsiveSize}
                 />
               </Layer>
             </TableToolbarContent>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Adds responsive sizing to the search toolbar in the lab orders data table. The search input now adjusts its size based on the device layout type—displaying larger on tablets and smaller on desktop—for improved usability across screen sizes.

## Screenshots
Before - 
<img width="1652" height="132" alt="Screenshot 2026-06-12 at 2 36 11 PM" src="https://github.com/user-attachments/assets/dd1359cd-ba20-42e5-b6c0-d914844c5303" />

After - 
<img width="1652" height="132" alt="Screenshot 2026-06-12 at 2 35 25 PM" src="https://github.com/user-attachments/assets/e0579e88-60fe-4b30-a9df-64a9cafecc02" />


## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
