### PR TITLE
(feat) O3-5744: Display patient identifier and order reason in the laboratory orders table

### DIFF
--- a/src/components/orders-table/list-order-details.component.tsx
+++ b/src/components/orders-table/list-order-details.component.tsx
@@ -41,6 +41,16 @@ const ListOrderDetails: React.FC<ListOrdersDetailsProps> = ({ groupedOrders }) =
   const { t } = useTranslation();
   const originalOrders = groupedOrders?.originalOrders ?? [];
 
+  const getOrderReason = (order: (typeof originalOrders)[number]) => {
+    if (order?.orderReason) {
+      return order.orderReason.display;
+    } else if (order?.orderReasonNonCoded) {
+      return order.orderReasonNonCoded;
+    } else {
+      return '--';
+    }
+  };
+
   return (
     <div>
       {originalOrders.map((order) => (
@@ -75,6 +85,7 @@ const ListOrderDetails: React.FC<ListOrdersDetailsProps> = ({ groupedOrders }) =
                 value={formatDate(parseDate(order.dateActivated))}
               />
               <OrderDetailRow label={t('orderedBy', 'Ordered By:')} value={order.orderer?.display} />
+              <OrderDetailRow label={t('orderReason', 'Order reason:')} value={getOrderReason(order)} />
               <OrderDetailRow
                 label={t('orderInstructions', 'Instructions:')}
                 value={order.instructions ?? t('NoInstructionLeft', 'No instructions are provided.')}

--- a/src/components/orders-table/list-order-details.test.tsx
+++ b/src/components/orders-table/list-order-details.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Order } from '@openmrs/esm-framework';
+import { type GroupedOrders } from '../../types';
+import ListOrderDetails from './list-order-details.component';
+
+const baseOrder = {
+  uuid: 'order-uuid-1',
+  orderNumber: 'ORD-001',
+  display: 'Blood Test',
+  dateActivated: '2021-06-01',
+  fulfillerStatus: 'RECEIVED',
+  urgency: null,
+  orderer: { uuid: 'orderer-uuid-1', display: 'Dr. Test', person: { display: 'Dr. Test' } },
+  instructions: null,
+  fulfillerComment: null,
+};
+
+const makeGroupedOrders = (orderPatch: object = {}): GroupedOrders => ({
+  patientUuid: 'patient-uuid-1',
+  totalOrders: 1,
+  urgencyCounts: {},
+  orders: [],
+  originalOrders: [{ ...baseOrder, ...orderPatch } as unknown as Order],
+});
+
+describe('ListOrderDetails — order reason', () => {
+  it('shows the coded order reason display when orderReason is set', () => {
+    render(
+      <ListOrderDetails
+        groupedOrders={makeGroupedOrders({ orderReason: { uuid: 'concept-uuid-1', display: 'Fever screening' } })}
+      />,
+    );
+
+    expect(screen.getByText('Order reason:')).toBeInTheDocument();
+    expect(screen.getByText('Fever screening')).toBeInTheDocument();
+  });
+
+  it('shows the non-coded order reason when only orderReasonNonCoded is set', () => {
+    render(
+      <ListOrderDetails
+        groupedOrders={makeGroupedOrders({ orderReasonNonCoded: 'Patient requested routine check' })}
+      />,
+    );
+
+    expect(screen.getByText('Patient requested routine check')).toBeInTheDocument();
+  });
+
+  it('shows "--" when neither orderReason nor orderReasonNonCoded is set', () => {
+    render(<ListOrderDetails groupedOrders={makeGroupedOrders()} />);
+
+    expect(screen.getByText('Order reason:')).toBeInTheDocument();
+    expect(screen.getByText('--')).toBeInTheDocument();
+  });
+
+  it('prefers the coded orderReason over orderReasonNonCoded when both are set', () => {
+    render(
+      <ListOrderDetails
+        groupedOrders={makeGroupedOrders({
+          orderReason: { uuid: 'concept-uuid-2', display: 'Malaria screening' },
+          orderReasonNonCoded: 'Should not appear',
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Malaria screening')).toBeInTheDocument();
+    expect(screen.queryByText('Should not appear')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/orders-table/orders-data-table.component.tsx
+++ b/src/components/orders-table/orders-data-table.component.tsx
@@ -36,7 +36,7 @@ import {
 import { OrdersDateRangePicker } from './orders-date-range-picker.component';
 import ListOrderDetails from './list-order-details.component';
 import { useLabOrders } from '../../laboratory.resource';
-import { urgencyTagType, formatUrgencyLabel, urgencyPriority } from '../../utils';
+import { urgencyTagType, formatUrgencyLabel, urgencyPriority, getPatientIdentifier } from '../../utils';
 import type { FulfillerStatus, FlattenedOrder, Order } from '../../types';
 import { type Config } from '../../config-schema';
 import styles from './orders-data-table.scss';
@@ -105,7 +105,7 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
   const { t } = useTranslation();
   const [filter, setFilter] = useState<FulfillerStatus>(null);
   const [searchString, setSearchString] = useState('');
-  const { labTableColumns, patientIdIdentifierTypeUuid } = useConfig<Config>();
+  const { labTableColumns, patientIdIdentifierTypeUuid, usePreferredPatientIdentifier } = useConfig<Config>();
   const isTablet = useLayoutType() === 'tablet';
   const responsiveSize: 'sm' | 'lg' = isTablet ? 'lg' : 'sm';
 
@@ -153,12 +153,7 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
         }, {} as Record<string, number>);
 
         return {
-          patientId: patient?.identifiers?.find(
-            (identifier) =>
-              identifier.preferred &&
-              !identifier.voided &&
-              identifier.identifierType.uuid === patientIdIdentifierTypeUuid,
-          )?.identifier,
+          patientId: getPatientIdentifier(patient, patientIdIdentifierTypeUuid, usePreferredPatientIdentifier),
           patientUuid: patientUuid,
           patientName: patient?.person?.display,
           patientAge: patient?.person?.age,
@@ -173,7 +168,7 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
     } else {
       return [];
     }
-  }, [flattenedLabOrders, labOrders, patientIdIdentifierTypeUuid]);
+  }, [flattenedLabOrders, labOrders, patientIdIdentifierTypeUuid, usePreferredPatientIdentifier]);
 
   const searchResults = useMemo(() => {
     if (searchString && searchString.trim() !== '') {

--- a/src/components/orders-table/orders-data-table.test.tsx
+++ b/src/components/orders-table/orders-data-table.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { beforeEach, describe, expect, it, vi, vitest } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useConfig, getDefaultsFromConfigSchema, type Order, type Patient } from '@openmrs/esm-framework';
@@ -320,7 +320,7 @@ describe('patient identifier column', () => {
     ] as unknown as Array<Order>,
     isLoading: false,
     isError: false,
-    mutate: vitest.fn(),
+    mutate: vi.fn(),
     isValidating: false,
   });
 
@@ -471,7 +471,7 @@ describe('patient identifier column', () => {
         },
       ]),
     );
-    mockUseConfig.mockReturnValue(baseConfig);
+    mockUseConfig.mockReturnValue({ ...baseConfig, usePreferredPatientIdentifier: false });
 
     render(<OrdersDataTable />);
     const row = screen

--- a/src/components/orders-table/orders-data-table.test.tsx
+++ b/src/components/orders-table/orders-data-table.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, vitest } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useConfig, getDefaultsFromConfigSchema, type Order, type Patient } from '@openmrs/esm-framework';
@@ -216,7 +216,7 @@ describe('OrdersDataTable', () => {
           fulfillerComment: null,
           display: 'Null Urgency Test',
         },
-      ] as Array<Order>,
+      ] as unknown as Array<Order>,
       isLoading: false,
       isError: false,
       mutate: vi.fn(),
@@ -250,7 +250,7 @@ describe('OrdersDataTable', () => {
           fulfillerComment: null,
           display: 'Scheduled Test',
         },
-      ] as Array<Order>,
+      ] as unknown as Array<Order>,
       isLoading: false,
       isError: false,
       mutate: vi.fn(),
@@ -285,5 +285,229 @@ describe('OrdersDataTable', () => {
     expect(row2).toHaveTextContent('60');
     expect(row2).toHaveTextContent('1');
     expect(screen.queryByText(/BAD-ID/)).not.toBeInTheDocument();
+  });
+});
+
+describe('patient identifier column', () => {
+  const TYPE_UUID = 'identifier-type-uuid-1';
+  const OTHER_UUID = 'other-type-uuid';
+
+  const baseConfig: Config = {
+    ...(getDefaultsFromConfigSchema(configSchema) as Config),
+    labTableColumns: ['patientId', 'age', 'totalOrders'],
+    patientIdIdentifierTypeUuid: TYPE_UUID,
+  };
+
+  const makeOrder = (identifiers: Patient['identifiers']) => ({
+    labOrders: [
+      {
+        uuid: 'order-uuid-x',
+        orderNumber: 'ORD-X',
+        patient: {
+          uuid: 'patient-uuid-x',
+          display: 'Test Patient',
+          identifiers,
+          person: { uuid: 'person-uuid-x', display: 'Test Patient', age: 40, gender: 'F' },
+        } as Patient,
+        dateActivated: '2021-01-01',
+        fulfillerStatus: 'RECEIVED',
+        urgency: 'ROUTINE',
+        orderer: { uuid: 'orderer-uuid-x', display: 'Dr. Test', person: { display: 'Dr. Test' } },
+        instructions: '',
+        fulfillerComment: null,
+        display: 'Test Order',
+      },
+    ] as unknown as Array<Order>,
+    isLoading: false,
+    isError: false,
+    mutate: vitest.fn(),
+    isValidating: false,
+  });
+
+  it('shows "--" when the patient has no identifiers', () => {
+    mockUseLabOrders.mockReturnValueOnce(makeOrder(undefined));
+    mockUseConfig.mockReturnValue(baseConfig);
+
+    render(<OrdersDataTable />);
+    const row = screen
+      .getAllByRole('row')
+      .slice(1)
+      .find((r) => !r.classList.contains('hiddenRow'));
+    expect(row).toHaveTextContent('--');
+  });
+
+  it('shows "--" when no identifier matches the configured type UUID and there is no preferred fallback', () => {
+    mockUseLabOrders.mockReturnValueOnce(
+      makeOrder([
+        {
+          uuid: 'id-1',
+          identifier: 'WRONG-TYPE',
+          preferred: false,
+          voided: false,
+          identifierType: { uuid: OTHER_UUID },
+        },
+      ]),
+    );
+    mockUseConfig.mockReturnValue(baseConfig);
+
+    render(<OrdersDataTable />);
+    const row = screen
+      .getAllByRole('row')
+      .slice(1)
+      .find((r) => !r.classList.contains('hiddenRow'));
+    expect(row).toHaveTextContent('--');
+    expect(row).not.toHaveTextContent('WRONG-TYPE');
+  });
+
+  it('shows the configured-type identifier when usePreferredPatientIdentifier is false', () => {
+    mockUseLabOrders.mockReturnValueOnce(
+      makeOrder([
+        {
+          uuid: 'id-1',
+          identifier: 'NON-PREF-MATCH',
+          preferred: false,
+          voided: false,
+          identifierType: { uuid: TYPE_UUID },
+        },
+        {
+          uuid: 'id-2',
+          identifier: 'PREF-NO-MATCH',
+          preferred: true,
+          voided: false,
+          identifierType: { uuid: OTHER_UUID },
+        },
+      ]),
+    );
+    mockUseConfig.mockReturnValue({ ...baseConfig, usePreferredPatientIdentifier: false });
+
+    render(<OrdersDataTable />);
+    const row = screen
+      .getAllByRole('row')
+      .slice(1)
+      .find((r) => !r.classList.contains('hiddenRow'));
+    expect(row).toHaveTextContent('NON-PREF-MATCH');
+    expect(row).not.toHaveTextContent('PREF-NO-MATCH');
+  });
+
+  it('shows only the preferred matching identifier when usePreferredPatientIdentifier is true', () => {
+    mockUseLabOrders.mockReturnValueOnce(
+      makeOrder([
+        {
+          uuid: 'id-1',
+          identifier: 'NON-PREF-MATCH',
+          preferred: false,
+          voided: false,
+          identifierType: { uuid: TYPE_UUID },
+        },
+        { uuid: 'id-2', identifier: 'PREF-MATCH', preferred: true, voided: false, identifierType: { uuid: TYPE_UUID } },
+      ]),
+    );
+    mockUseConfig.mockReturnValue({ ...baseConfig, usePreferredPatientIdentifier: true });
+
+    render(<OrdersDataTable />);
+    const row = screen
+      .getAllByRole('row')
+      .slice(1)
+      .find((r) => !r.classList.contains('hiddenRow'));
+    expect(row).toHaveTextContent('PREF-MATCH');
+    expect(row).not.toHaveTextContent('NON-PREF-MATCH');
+  });
+
+  it('shows "--" when usePreferredPatientIdentifier is true but no preferred identifier matches the type', () => {
+    mockUseLabOrders.mockReturnValueOnce(
+      makeOrder([
+        {
+          uuid: 'id-1',
+          identifier: 'NON-PREF-MATCH',
+          preferred: false,
+          voided: false,
+          identifierType: { uuid: TYPE_UUID },
+        },
+      ]),
+    );
+    mockUseConfig.mockReturnValue({ ...baseConfig, usePreferredPatientIdentifier: true });
+
+    render(<OrdersDataTable />);
+    const row = screen
+      .getAllByRole('row')
+      .slice(1)
+      .find((r) => !r.classList.contains('hiddenRow'));
+    expect(row).toHaveTextContent('--');
+    expect(row).not.toHaveTextContent('NON-PREF-MATCH');
+  });
+
+  it('does not show voided identifiers even if they match the type UUID', () => {
+    mockUseLabOrders.mockReturnValueOnce(
+      makeOrder([
+        {
+          uuid: 'id-1',
+          identifier: 'VOIDED-MATCH',
+          preferred: true,
+          voided: true,
+          identifierType: { uuid: TYPE_UUID },
+        },
+      ]),
+    );
+    mockUseConfig.mockReturnValue(baseConfig);
+
+    render(<OrdersDataTable />);
+    const row = screen
+      .getAllByRole('row')
+      .slice(1)
+      .find((r) => !r.classList.contains('hiddenRow'));
+    expect(row).toHaveTextContent('--');
+    expect(row).not.toHaveTextContent('VOIDED-MATCH');
+  });
+
+  it('falls back to the preferred identifier when no identifier matches the configured type UUID', () => {
+    mockUseLabOrders.mockReturnValueOnce(
+      makeOrder([
+        {
+          uuid: 'id-1',
+          identifier: 'PREF-FALLBACK',
+          preferred: true,
+          voided: false,
+          identifierType: { uuid: OTHER_UUID },
+        },
+      ]),
+    );
+    mockUseConfig.mockReturnValue(baseConfig);
+
+    render(<OrdersDataTable />);
+    const row = screen
+      .getAllByRole('row')
+      .slice(1)
+      .find((r) => !r.classList.contains('hiddenRow'));
+    expect(row).toHaveTextContent('PREF-FALLBACK');
+  });
+
+  it('shows the type-UUID match and not the preferred-fallback when both exist', () => {
+    mockUseLabOrders.mockReturnValueOnce(
+      makeOrder([
+        {
+          uuid: 'id-1',
+          identifier: 'PREF-OTHER',
+          preferred: true,
+          voided: false,
+          identifierType: { uuid: OTHER_UUID },
+        },
+        {
+          uuid: 'id-2',
+          identifier: 'CONFIGURED',
+          preferred: false,
+          voided: false,
+          identifierType: { uuid: TYPE_UUID },
+        },
+      ]),
+    );
+    mockUseConfig.mockReturnValue({ ...baseConfig, usePreferredPatientIdentifier: false });
+
+    render(<OrdersDataTable />);
+    const row = screen
+      .getAllByRole('row')
+      .slice(1)
+      .find((r) => !r.classList.contains('hiddenRow'));
+    expect(row).toHaveTextContent('CONFIGURED');
+    expect(row).not.toHaveTextContent('PREF-OTHER');
   });
 });

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -23,6 +23,12 @@ export const configSchema = {
     _default: '05a29f94-c0ed-11e2-94be-8c13b969e334',
     _description: 'Needed if the "id" column of "labTableColumns" is used. Is the OpenMRS ID by default.',
   },
+  usePreferredPatientIdentifier: {
+    _type: Type.Boolean,
+    _default: false,
+    _description:
+      'Use preferred patient identifier. When enabled, the preferred patient identifier will be used in the "id" column of the lab table instead of the OpenMRS ID.',
+  },
   enableReviewingLabResultsBeforeApproval: {
     _type: Type.Boolean,
     _default: false,
@@ -36,4 +42,5 @@ export type Config = {
   laboratoryOrderTypeUuid: string;
   labTableColumns: Array<LabTableColumnName>;
   patientIdIdentifierTypeUuid: string;
+  usePreferredPatientIdentifier: boolean;
 };

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -25,9 +25,9 @@ export const configSchema = {
   },
   usePreferredPatientIdentifier: {
     _type: Type.Boolean,
-    _default: false,
+    _default: true,
     _description:
-      'Use preferred patient identifier. When enabled, the preferred patient identifier will be used in the "id" column of the lab table instead of the OpenMRS ID.',
+      "When true (default), the patientId column shows an identifier only when it is both preferred and matches patientIdIdentifierTypeUuid. When false, any identifier of the configured type is shown regardless of preferred status, with a fallback to the patient's preferred identifier of any type.",
   },
   enableReviewingLabResultsBeforeApproval: {
     _type: Type.Boolean,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { type Concept, type Order as FrameworkOrder, type OrderUrgency } from '@openmrs/esm-framework';
+import { type Order as FrameworkOrder, type OrderUrgency } from '@openmrs/esm-framework';
 
 type FrameworkFulfillerStatus = FrameworkOrder['fulfillerStatus'];
 export type FulfillerStatus = FrameworkFulfillerStatus | 'DRAFT' | null;
@@ -19,8 +19,6 @@ export interface FlattenedOrder {
   orderer?: string;
   instructions?: string;
   fulfillerComment?: string;
-  orderReason?: Concept;
-  orderReasonNonCoded?: string;
 }
 
 export interface GroupedOrders {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { type Order as FrameworkOrder, type OrderUrgency } from '@openmrs/esm-framework';
+import { type Concept, type Order as FrameworkOrder, type OrderUrgency } from '@openmrs/esm-framework';
 
 type FrameworkFulfillerStatus = FrameworkOrder['fulfillerStatus'];
 export type FulfillerStatus = FrameworkFulfillerStatus | 'DRAFT' | null;
@@ -19,6 +19,8 @@ export interface FlattenedOrder {
   orderer?: string;
   instructions?: string;
   fulfillerComment?: string;
+  orderReason?: Concept;
+  orderReasonNonCoded?: string;
 }
 
 export interface GroupedOrders {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { capitalize } from 'lodash-es';
 import { type TFunction } from 'i18next';
-import { type OrderUrgency } from '@openmrs/esm-framework';
+import { type Patient, type OrderUrgency } from '@openmrs/esm-framework';
 
 export const urgencyTagType: Record<OrderUrgency, 'red' | 'green' | 'gray'> = {
   STAT: 'red',
@@ -26,3 +26,20 @@ export function formatUrgencyLabel(
       return capitalize(urgency.replace(/_/g, ' ').toLowerCase());
   }
 }
+
+export const getPatientIdentifier = (
+  patient: Patient | undefined,
+  patientIdIdentifierTypeUuid: string,
+  usePreferredPatientIdentifier: boolean,
+) => {
+  const configuredPatientId = patient?.identifiers?.find(
+    (identifier) =>
+      (usePreferredPatientIdentifier ? identifier.preferred : true) &&
+      !identifier.voided &&
+      identifier?.identifierType?.uuid === patientIdIdentifierTypeUuid,
+  )?.identifier;
+
+  const preferredIdentifier = patient?.identifiers?.find((identifier) => identifier.preferred && !identifier.voided);
+
+  return configuredPatientId || (preferredIdentifier?.identifier ?? '--');
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,14 +32,25 @@ export const getPatientIdentifier = (
   patientIdIdentifierTypeUuid: string,
   usePreferredPatientIdentifier: boolean,
 ) => {
-  const configuredPatientId = patient?.identifiers?.find(
-    (identifier) =>
-      (usePreferredPatientIdentifier ? identifier.preferred : true) &&
-      !identifier.voided &&
-      identifier?.identifierType?.uuid === patientIdIdentifierTypeUuid,
+  if (usePreferredPatientIdentifier) {
+    // Default/old behavior: identifier must be both preferred and match the configured type.
+    return (
+      patient?.identifiers?.find(
+        (identifier) =>
+          identifier.preferred &&
+          !identifier.voided &&
+          identifier?.identifierType?.uuid === patientIdIdentifierTypeUuid,
+      )?.identifier ?? '--'
+    );
+  }
+
+  // Opt-in behavior: first match identifiers by the configured type, regardless of the preferred flag.
+  // If no matching type is found, fall back to any preferred identifier of any type, then '--'.
+  const byType = patient?.identifiers?.find(
+    (identifier) => !identifier.voided && identifier?.identifierType?.uuid === patientIdIdentifierTypeUuid,
   )?.identifier;
 
-  const preferredIdentifier = patient?.identifiers?.find((identifier) => identifier.preferred && !identifier.voided);
+  const anyPreferred = patient?.identifiers?.find((identifier) => identifier.preferred && !identifier.voided);
 
-  return configuredPatientId || (preferredIdentifier?.identifier ?? '--');
+  return byType ?? anyPreferred?.identifier ?? '--';
 };

--- a/translations/en.json
+++ b/translations/en.json
@@ -45,6 +45,7 @@
   "orderNotPicked": "Order not picked",
   "orderNumbers": "Order number:",
   "orderPickedSuccessfully": "You have successfully picked an order",
+  "orderReason": "Order reason:",
   "orders": "Orders",
   "orderStatus": "Status:",
   "patient": "Patient",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary
See https://openmrs.atlassian.net/browse/O3-5744
- Add **usePreferredPatientIdentifier** config option — Introduces a new boolean flag, defaulting to `true`. When `true` (the default, preserving the existing behavior), the lab table patient ID column displays an identifier only when it is both preferred and matches the configured identifier type, otherwise `--`. When `false`, it displays any identifier of the configured type regardless of preferred status, falling back to the patient's preferred identifier of any type, or `--` if none exists.
- Display order reason in order details — Updates ListOrderDetails to render an Order reason: row for each order. The value is resolved from orderReason.display for coded reasons, orderReasonNonCoded for free-text reasons, or -- when neither is available.

## Screenshots
https://github.com/user-attachments/assets/db3a08fd-542a-48d3-a623-2b28b6f91f66

## Related Issue
https://openmrs.atlassian.net/browse/O3-5744
https://thepalladiumgroup.atlassian.net/browse/KHP3-9300

## Other
<!-- Anything not covered above -->
