### PR TITLE
(feat) GNL-804: Add an icon to the laboratory home dashboard link

### DIFF
--- a/src/components/create-dashboard-link.component.tsx
+++ b/src/components/create-dashboard-link.component.tsx
@@ -1,37 +1,27 @@
-import React, { useMemo } from 'react';
-import { ConfigurableLink } from '@openmrs/esm-framework';
-import { BrowserRouter, useLocation } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
+import React from 'react';
+import { DashboardExtension, type IconId } from '@openmrs/esm-framework';
+import { BrowserRouter } from 'react-router-dom';
 
 export interface DashboardLinkConfig {
   name: string;
   title: string;
+  icon?: IconId;
 }
 
-function DashboardExtension({ dashboardLinkConfig }: { dashboardLinkConfig: DashboardLinkConfig }) {
-  const { t } = useTranslation();
-  const { name, title } = dashboardLinkConfig;
-  const location = useLocation();
-  const spaBasePath = `${window.spaBase}/home`;
-
-  const isActive = useMemo(() => {
-    const pathSegments = location.pathname.split('/').map((segment) => decodeURIComponent(segment));
-    return pathSegments.includes(name);
-  }, [location.pathname, name]);
-
+function HomeDashboardLink({ dashboardLinkConfig }: { dashboardLinkConfig: DashboardLinkConfig }) {
   return (
-    <ConfigurableLink
-      to={`${spaBasePath}/${name}`}
-      className={`cds--side-nav__link ${isActive ? 'active-left-nav-link' : ''}`}
-    >
-      {t(title)}
-    </ConfigurableLink>
+    <DashboardExtension
+      path={dashboardLinkConfig.name}
+      title={dashboardLinkConfig.title}
+      basePath={`${window.spaBase}/home`}
+      icon={dashboardLinkConfig.icon}
+    />
   );
 }
 
 export const createHomeDashboardLink = (dashboardLinkConfig: DashboardLinkConfig) => () =>
   (
     <BrowserRouter>
-      <DashboardExtension dashboardLinkConfig={dashboardLinkConfig} />
+      <HomeDashboardLink dashboardLinkConfig={dashboardLinkConfig} />
     </BrowserRouter>
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export const laboratoryDashboardLink = getSyncLifecycle(
   createHomeDashboardLink({
     name: 'laboratory',
     title: 'Laboratory',
+    icon: 'omrs-icon-microscope',
   }),
   options,
 );


### PR DESCRIPTION
## Requirements

- [x] This PR has a conventional title that includes the implementation ticket number.
- [x] This follows the existing OpenMRS home dashboard icon pattern; no new design is introduced.
- [x] The change is validated by the repository pre-push checks.

## Summary

Replaces the laboratory app’s custom home-link rendering with the framework `DashboardExtension` and adds the standard microscope icon. Using the shared component keeps active-state, path, title, and icon rendering consistent with other OpenMRS home dashboard links.

## Screenshots

Not attached. The change adopts the existing framework dashboard-link presentation and standard `omrs-icon-microscope` icon.

## Related Issue

GNL-804 — Cleanup the home page iconography (downstream implementation issue).

## Other

Lint, TypeScript, and all 33 automated tests passed.