### PR TITLE
(fix) Clamp lab order pagination after filter changes

### DIFF
--- a/src/components/orders-table/orders-data-table.component.tsx
+++ b/src/components/orders-table/orders-data-table.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   DataTable,
   DataTableSkeleton,
@@ -206,6 +206,13 @@ const OrdersDataTable: React.FC<OrdersDataTableProps> = (props) => {
   const pageSizes = [10, 20, 30, 40, 50];
   const [currentPageSize, setPageSize] = useState(10);
   const { goTo, results: paginatedLabOrders, currentPage } = usePagination(searchResults, currentPageSize);
+  const totalPages = Math.max(1, Math.ceil(searchResults.length / currentPageSize));
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      goTo(totalPages);
+    }
+  }, [currentPage, goTo, totalPages]);
 
   const handleOrderStatusChange = ({ selectedItem }: { selectedItem: { value: FulfillerStatus; display: string } }) =>
     setFilter(selectedItem.value);

--- a/src/components/orders-table/orders-data-table.test.tsx
+++ b/src/components/orders-table/orders-data-table.test.tsx
@@ -137,6 +137,42 @@ function mockUseLabOrdersImplementation(props: Parameters<typeof useLabOrders>[0
   };
 }
 
+function makePagedOrders(count: number) {
+  const orderer = {
+    uuid: 'orderer-uuid-1',
+    display: 'Dr. John Doe',
+    person: {
+      display: 'Dr. John Doe',
+    },
+  };
+
+  return Array.from({ length: count }, (_, index) => {
+    const paddedIndex = String(index + 1).padStart(2, '0');
+
+    return {
+      uuid: `order-uuid-${paddedIndex}`,
+      orderNumber: `ORD-${paddedIndex}`,
+      patient: {
+        uuid: `patient-uuid-${paddedIndex}`,
+        display: `PAT-${paddedIndex} - Patient ${paddedIndex}`,
+        person: {
+          uuid: `person-uuid-${paddedIndex}`,
+          display: `Patient ${paddedIndex}`,
+          age: 30 + index,
+          gender: index % 2 === 0 ? 'F' : 'M',
+        },
+      } as Patient,
+      dateActivated: '2021-01-01',
+      fulfillerStatus: 'RECEIVED',
+      urgency: 'ROUTINE',
+      orderer,
+      instructions: 'Routine check',
+      fulfillerComment: null,
+      display: `Test Order ${paddedIndex}`,
+    } as Order;
+  });
+}
+
 describe('OrdersDataTable', () => {
   beforeEach(() => {
     mockUseLabOrders.mockImplementation(mockUseLabOrdersImplementation);
@@ -307,6 +343,30 @@ describe('OrdersDataTable', () => {
     expect(row2).toHaveTextContent('60');
     expect(row2).toHaveTextContent('1');
     expect(screen.queryByText(/BAD-ID/)).not.toBeInTheDocument();
+  });
+
+  it('returns to a valid page when search results shrink below the current pagination page', async () => {
+    mockUseLabOrders.mockReturnValue({
+      labOrders: makePagedOrders(11),
+      isLoading: false,
+      isError: false,
+      mutate: vi.fn(),
+      isValidating: false,
+    });
+    mockUseConfig.mockReturnValue({
+      ...getDefaultsFromConfigSchema(configSchema),
+    });
+
+    const user = userEvent.setup();
+    render(<OrdersDataTable />);
+
+    await user.click(screen.getByRole('button', { name: /next page/i }));
+    expect(await screen.findByText('Patient 11')).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText('Search this list'), 'Patient 01');
+
+    expect(await screen.findByText('Patient 01')).toBeInTheDocument();
+    expect(screen.queryByText('No lab requests found')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done.
- [x] This change does not require new visual designs.
- [x] My work includes tests and has been validated by the existing test suite.

## Summary

Filtering the laboratory orders table could leave pagination on a page that no longer existed. This caused the table to display an empty state even when matching orders were available on an earlier page.

This change:

- calculates the final valid page from the filtered result count and current page size
- moves pagination to that page when the current page becomes invalid
- adds a regression test covering navigation to page 2 followed by a search that reduces the result set to one page

## Screenshots

Not included in this draft. The change corrects pagination behavior without changing the table's visual design.

## Related Issue

None.

## Other

Verification completed successfully:

- focused orders table tests: 15 passed
- complete repository tests: 34 passed
- focused ESLint checks
- TypeScript compilation
- complete repository verification
- production build
- diff and changed-file scope checks
